### PR TITLE
fix: switch our compose config to enable a dev workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# follow a whitelist approach
+**
+
+!.npmrc
+!package*.json

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# this lists the env variables needed for the app to work
+# create a copy of this file named .env,
+# then set the variables below to the correct values
+CLIENT_PORT=<same_as_apps/client/.env>
+SERVER_PORT=<same_as_apps/server/.env>

--- a/README.md
+++ b/README.md
@@ -10,16 +10,21 @@ TDB
 ```txt
 root/
 ├── README.md
+├── docker-compose.yaml
 ├── package-lock.json
 ├── package.json
+├── .env
 ├── docs/
 └── apps/
     ├── client/
+    │   ├── Dockerfile
+    |   ├── package.json
     |   ├── package.json
     │   ├── .env
     │   └── src/
     │       └── main.tsx
     └── server/
+    │   ├── Dockerfile
         ├── package.json
         ├── .env
         └── src/
@@ -28,20 +33,28 @@ root/
 
 ## Dev setup
 
-1. Specify env vars for each workspace as referenced in `.env.example`
-2. Install dependencies from the monorepo's root
+1. Specify env vars for root and each workspace as referenced in `.env.example`
+2. spin up dev containers through compose
 
    ```sh
    # from the root of the repo
-   npm ci
+   docker compose up --build -d
+   docker compose logs -f
    ```
 
-3. Start the backend and frontend dev servers
+   - if you only need 1 workspace, you can spin its related container instead
+
+      ```sh
+      # spins only the backend's container, named `server` in the compose file 
+      docker compose up --build -d server
+      docker compose logs -f server
+      ```
+
+3. stop the containers when done
 
    ```sh
-   # from the root of the repo on separate terminals
-   npm run server:dev
-   npm run client:dev
+   # from the root of the repo once again
+   docker compose down -v
    ```
 
 ## Deployment URLS

--- a/apps/client/.dockerignore
+++ b/apps/client/.dockerignore
@@ -1,2 +1,10 @@
-node_modules
-.env
+# follow a whitelist approach
+**
+
+!public/
+!src/
+!index.html
+!nginx.conf
+!package.json
+!tsconfig*.json
+!vite.config.ts

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,41 +1,26 @@
-# Build stage
-FROM node:20-alpine AS build
+# escape=`
+# oldest supported node version for `@vitejs/plugin-react@5.0.0`
+FROM node:20.19.0-alpine AS base
+WORKDIR /home/node/app/
 
-# Set working directory
-WORKDIR /app
+# defined as additional_context
+COPY --from=monorepo-root package*.json .npmrc ./
+COPY package.json apps/client/
+RUN npm ci --workspace=@pr-viewer/client
 
-# Copy package files
-COPY package*.json ./
+FROM base AS build
+WORKDIR /home/node/app/
 
-# Install dependencies
-RUN npm i
+COPY ./ apps/client/
+RUN npm run client:build
 
-# Declare a build argument for the backend URL
-ARG VITE_BACKEND_URL
+FROM nginx:alpine AS prod
+RUN chown -R nginx:nginx /var/cache/nginx/ /var/run/
+USER nginx:nginx
 
-# Set the environment variable using the build argument.
-ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+COPY --chown=nginx:nginx --from=build /home/node/app/apps/client/dist/ /usr/share/nginx/html/
+COPY --chown=nginx:nginx nginx.conf /etc/nginx/conf.d/default.conf
 
-# Copy source code
-COPY . .
+EXPOSE 8080
 
-# Build the application
-RUN npm run build
-
-# Production stage
-FROM nginx:alpine
-
-# Create logs directory
-RUN mkdir -p /var/log/nginx
-
-# Copy custom nginx config
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-
-# Copy built assets from build stage
-COPY --from=build /app/dist /usr/share/nginx/html
-
-# Expose port
-EXPOSE 80
-
-# Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
 
     root /usr/share/nginx/html;

--- a/apps/server/.dockerignore
+++ b/apps/server/.dockerignore
@@ -1,2 +1,6 @@
-node_modules
-.env
+# follow a whitelist approach
+**
+
+!src/
+!package.json
+!tsconfig.json

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -1,53 +1,32 @@
-# Build stage
-FROM node:20-alpine AS build
+# escape=`
+# oldest supported node version for `node --watch`
+FROM node:20.13.0-alpine AS base
+WORKDIR /home/node/app/
 
-# Set working directory
-WORKDIR /app
+# defined as additional_context
+COPY --from=monorepo-root package*.json .npmrc ./
+COPY package.json apps/server/
+RUN npm ci --workspace=@pr-viewer/server
 
-# Copy package files
-COPY package*.json ./
+FROM base AS build
+WORKDIR /home/node/app/
 
-# Install all dependencies
-RUN npm i
+COPY ./ apps/server/
+RUN npm run server:build
 
-# Copy source code
-COPY . .
+FROM node:20.13.0-alpine AS prod
+USER node:node
+WORKDIR /home/node/app/
 
-# Build TypeScript to JavaScript
-RUN npm run build
+ENV NODE_ENV=production
 
-# Production stage
-FROM node:20-alpine AS production
+COPY --chown=node:node --from=monorepo-root package*.json .npmrc ./
+COPY --chown=node:node package.json apps/server/
+RUN npm ci --omit=dev --workspace=@pr-viewer/server
 
-# Set working directory
-WORKDIR /app
+COPY --chown=node:node --from=build /home/node/app/apps/server/dist/ apps/server/dist/
 
-# Copy package files
-COPY package*.json ./
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 `
+  CMD curl -f http://localhost:${PORT}/health || exit 1
 
-# Install all dependencies
-RUN npm i
-
-# Keep production dependencies only for runtime
-RUN npm prune --omit=dev
-
-# Copy built JavaScript files from build stage
-COPY --from=build /app/dist ./dist
-
-# Create non-root user for security
-RUN addgroup -g 1001 -S nodejs && \
-  adduser -S nodejs -u 1001
-
-# Change ownership of app directory
-RUN chown -R nodejs:nodejs /app
-USER nodejs
-
-# Expose the port your app runs on
-EXPOSE 3001
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD curl -f http://localhost:3001/health || exit 1
-
-# Start the application
-CMD ["node", "dist/server.js"]
+CMD ["node", "apps/server/dist/server.js"]

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -27,6 +27,6 @@ RUN npm ci --omit=dev --workspace=@pr-viewer/server
 COPY --chown=node:node --from=build /home/node/app/apps/server/dist/ apps/server/dist/
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 `
-  CMD curl -f http://localhost:${PORT}/health || exit 1
+  CMD sh -c 'wget -qO- http://localhost:$PORT/health || exit 1'
 
 CMD ["node", "apps/server/dist/server.js"]

--- a/apps/server/nodemon.json
+++ b/apps/server/nodemon.json
@@ -1,0 +1,8 @@
+{
+    "watch": ["src/"],
+    "ignore": ["node_modules/**"],
+    "ext": "ts",
+    "execMap": {
+      "ts": "node --no-warnings=ExperimentalWarning --loader ts-node/esm"
+    }
+  }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,7 +9,7 @@
     "node": "^20.13.0 || >= v22.0.0"
   },
   "scripts": {
-    "dev": "dotenvx run -- tsx --watch src/server.ts",
+    "dev": "dotenvx run -- nodemon src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js"
   },
@@ -21,6 +21,8 @@
     "@dotenvx/dotenvx": "1.49.0",
     "@types/cors": "^2.8.19",
     "@types/express": "5.0.3",
+    "nodemon": "^3.1.10",
+    "ts-node": "^10.9.2",
     "tsx": "4.20.5",
     "typescript": "5.9.2"
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,14 @@ services:
       context: apps/client/
       additional_contexts:
         - monorepo-root=./
+    environment:
+      # live reload features do not work (especially in windows envs)
+      # because of an OS issue where the file watchers cannot pick up
+      # fs events due to differing file systems.
+      # we resolve it by instructing the underlying file watchers
+      # behind dev servers to use polling instead (such as nodemon -L). see:
+      # https://github.com/privatenumber/tsx/issues/266#issuecomment-1638530253
+      - CHOKIDAR_USEPOLLING=true
     volumes:
       - ./apps/client/:/home/node/app/apps/client/
       - /home/node/app/apps/client/node_modules/
@@ -29,7 +37,7 @@ services:
       context: apps/server/
       additional_contexts:
         - monorepo-root=./
-    command: ["npm", "run", "server:dev"]
+    command: ["npm", "run", "server:dev", "--", "--", "-L"]
     volumes:
       - ./apps/server/:/home/node/app/apps/server/
       - /home/node/app/apps/server/node_modules/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,32 +1,44 @@
 services:
-  fe-pr-review:
+  web:
+    container_name: web
+    command: ["npm", "run", "client:dev", "--", "--", "--host"]
     build:
-      context: ./apps/client
+      target: base
       dockerfile: Dockerfile
-    container_name: fe-pr-review
+      context: apps/client/
+      additional_contexts:
+        - monorepo-root=./
+    volumes:
+      - ./apps/client/:/home/node/app/apps/client/
+      - /home/node/app/apps/client/node_modules/
     ports:
-      - "3000:8080"
-    env_file:
-      - ./apps/client/.env
-    depends_on:
-      - be-pr-review
+      - "${CLIENT_PORT}:${CLIENT_PORT}"
     networks:
-      - pr-review-network
+      - shared-net
+    depends_on:
+      - server
     restart: unless-stopped
 
-  be-pr-review:
+  server:
+    container_name: server
+    # see https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
+    init: true
     build:
-      context: ./apps/server
+      target: base
       dockerfile: Dockerfile
-    container_name: be-pr-review
+      context: apps/server/
+      additional_contexts:
+        - monorepo-root=./
+    command: ["npm", "run", "server:dev"]
+    volumes:
+      - ./apps/server/:/home/node/app/apps/server/
+      - /home/node/app/apps/server/node_modules/
     ports:
-      - "3000:3000"
-    env_file:
-      - ./apps/server/.env
+      - "${SERVER_PORT}:${SERVER_PORT}"
     networks:
-      - pr-review-network
+      - shared-net
     restart: unless-stopped
 
 networks:
-  pr-review-network:
+  shared-net:
     driver: bridge

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,11 +3,9 @@ services:
     build:
       context: ./apps/client
       dockerfile: Dockerfile
-      args:
-        - VITE_BACKEND_URL=${VITE_BACKEND_URL}
     container_name: fe-pr-review
     ports:
-      - "3000:80"
+      - "3000:8080"
     env_file:
       - ./apps/client/.env
     depends_on:
@@ -22,7 +20,7 @@ services:
       dockerfile: Dockerfile
     container_name: be-pr-review
     ports:
-      - "3001:3001"
+      - "3000:3000"
     env_file:
       - ./apps/server/.env
     networks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -569,6 +569,8 @@
         "@dotenvx/dotenvx": "1.49.0",
         "@types/cors": "^2.8.19",
         "@types/express": "5.0.3",
+        "nodemon": "^3.1.10",
+        "ts-node": "^10.9.2",
         "tsx": "4.20.5",
         "typescript": "5.9.2"
       },
@@ -870,6 +872,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -1624,6 +1650,34 @@
         "win32"
       ]
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1836,6 +1890,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1869,6 +1936,27 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1899,6 +1987,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -2063,6 +2164,44 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2171,6 +2310,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2233,6 +2379,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -3137,6 +3293,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3177,6 +3340,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
@@ -3362,6 +3538,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3514,6 +3697,81 @@
       "integrity": "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -3776,6 +4034,13 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3891,6 +4156,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -4192,6 +4470,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4317,6 +4621,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4328,6 +4642,50 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsx": {
@@ -4391,6 +4749,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -4448,6 +4813,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4495,6 +4867,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",


### PR DESCRIPTION
This is building off of #49 in relation to the resolved #37, while preserving the production minded work that @acto-acto already did (if/when we decide to have containerization in production). The changes are:
- [x] switching to a dev workflow setup
- [x] fixing live reload bugs dev servers face due to problems with receiving fs-events (especially on windows/wsl). We needed to switch from tsx to nodemon+ts-node because the former doesn't expose a flag to enable polling. [more info](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals)
- [x] updating the readme to reflect the changes

There are opportunities for improvement, notably:
- The addition of a Makefile for easier dev scripts. Typing `docker compose up --build -d && docker compose logs -f` most of the time is tedious after all.
- a script to autogenerate the root's `.env` every time docker spins up, removing the need to manually keep it in sync with service level `.env`s.