### PR TITLE
redirect ts-node errors to stderr

### DIFF
--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -17,5 +17,8 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "forceConsistentCasingInFileNames": true
+  },
+  "ts-node": {
+    "logError": true
   }
 }


### PR DESCRIPTION
fixes #76 by implementing the current workaround for ts-node. Ideally, they'll fix it upstream.